### PR TITLE
Tighten the packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,24 +56,18 @@ jobs:
       matrix:
         package:
           - centos7
+          - centos8
           - debian_stretch
           - debian_stretch_rpi3
-          - ubuntu_1604
-          - ubuntu_1804
-          - centos8
         include:
           - package: centos7
             artifact: packages/build/centos7/release/rpmbuild/RPMS/x86_64/ragent-0.1.0-1.x86_64.rpm
+          - package: centos8
+            artifact: packages/build/centos8/release/rpmbuild/RPMS/x86_64/ragent-0.1.0-1.x86_64.rpm
           - package: debian_stretch
             artifact: packages/build/debian_stretch/debian/ragent_0.1.0_amd64.deb
           - package: debian_stretch_rpi3
             artifact: packages/build/debian_stretch_rpi3/armv7-unknown-linux-gnueabihf/debian/ragent_0.1.0_armhf.deb
-          - package: ubuntu_1604
-            artifact: packages/build/ubuntu_1604/debian/ragent_0.1.0_amd64.deb
-          - package: ubuntu_1804
-            artifact: packages/build/ubuntu_1804/debian/ragent_0.1.0_amd64.deb
-          - package: centos8
-            artifact: packages/build/centos8/release/rpmbuild/RPMS/x86_64/ragent-0.1.0-1.x86_64.rpm
     steps:
       - uses: actions/checkout@v2
       - run: cd packages/ ; ./build_package ${{ matrix.package }}

--- a/README
+++ b/README
@@ -25,7 +25,7 @@ WHAT'S MONITORED
 * It verifies that no filesystem's free space is less than 2 GB or 20% free (warning) or less than 1 GB/10% (critical)
 * It verifies that no filesystem's free inodes are less than 20% free (warning) or less than 10% free (critical)
 * It verifies that no SystemD unit is in failed state (critical, or use --warning-units to define units which will only generate warnings)
-* It verifies that no reboot is required (Ubuntu, EL7, EL8)
+* It verifies that no reboot is required (EL7, EL8, Debian/Ubuntu)
 * It verifies that entropy is over 250 (critical) or 500 (warning) 
 
 BUILDING PACKAGES

--- a/packages/README
+++ b/packages/README
@@ -8,9 +8,8 @@ $ for image in $(grep FROM */Dockerfile | cut -d " " -f 2) ; do docker pull $ima
 
 Or build all packages in parallel:
 
-$ parallel ./build_package -- centos7 debian_stretch debian_stretch_rpi3 ubuntu_1604 ubuntu_1804 centos8
+$ parallel ./build_package -- centos7 centos8 debian_stretch debian_stretch_rpi3
 
 NOTES:
 
-* The Debian Stretch package works on Buster with no issues
-* The Ubuntu 18.04 package works on 20.04 with no issues
+* The Debian Stretch package works on Buster and Ubuntu 20.04 with no issues

--- a/packages/ubuntu_1604/Dockerfile
+++ b/packages/ubuntu_1604/Dockerfile
@@ -1,8 +1,0 @@
-FROM ubuntu:16.04
-RUN apt update
-RUN apt install -y curl build-essential  libssl-dev pkg-config
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-ENV PATH=/root/.cargo/bin:$PATH
-RUN cargo install cargo-deb
-WORKDIR /root/src/
-CMD cargo deb

--- a/packages/ubuntu_1804/Dockerfile
+++ b/packages/ubuntu_1804/Dockerfile
@@ -1,8 +1,0 @@
-FROM ubuntu:18.04
-RUN apt update
-RUN apt install -y curl build-essential  libssl-dev pkg-config
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-ENV PATH=/root/.cargo/bin:$PATH
-RUN cargo install cargo-deb
-WORKDIR /root/src/
-CMD cargo deb


### PR DESCRIPTION
Right now I only test EL7, EL8, Debian 9, Debian 10, and Ubuntu 20.04.
So I tested and EL7/EL8 require different packages, but the Debian 9
packages work for Debian 10, and Ubuntu 20.04, so I removed the 16.04
and 18.04 builds.